### PR TITLE
fix: update branch protection rules to include beta rust checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -51,8 +51,11 @@ branches:
         contexts:
           - "Security Audit"
           - "Test Suite (macos-latest, stable)"
+          - "Test Suite (macos-latest, beta)"
           - "Test Suite (ubuntu-latest, stable)"
+          - "Test Suite (ubuntu-latest, beta)"
           - "Test Suite (windows-latest, stable)"
+          - "Test Suite (windows-latest, beta)"
       
       # Enforces
       enforce_admins: false


### PR DESCRIPTION
## Summary
- Updated branch protection rules in `.github/settings.yml` to include all CI status checks
- Added beta Rust version checks alongside stable checks for all platforms (macos, ubuntu, windows)

## Why
The CI workflow runs tests on both stable and beta Rust versions, but the documented branch protection rules only included stable checks. This update ensures the documentation accurately reflects all required status checks.

## Test Plan
- [x] Verified current CI check names from recent PR #8
- [x] Updated settings.yml to include all 7 status checks (Security Audit + 6 Test Suite combinations)
- [ ] PR checks should pass with all status checks green