### PR TITLE
fix: add PR body and release body templates to release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,9 +9,40 @@ changelog_update = true
 git_release_enable = true
 git_tag_enable = true
 
+# Git release body template - ensures GitHub releases have proper content
+git_release_body = """
+## What's Changed
+
+{{ changelog }}
+
+**Full Changelog**: https://github.com/genai-rs/langfuse-ergonomic/compare/{{ previous_version }}...{{ version }}
+"""
+
 # PR settings
 pr_labels = ["release"]
 pr_draft = false
+
+# PR body template - ensures PR descriptions show the changelog
+pr_body = """
+## 📦 Package Updates
+
+This PR updates the following packages:
+
+{% for release in releases %}
+- **{{ release.package }}**: `{{ release.previous_version }}` → `{{ release.next_version }}`
+{% endfor %}
+
+## 📝 Changelog
+
+{% for release in releases %}
+### {{ release.package }}
+
+{{ release.changelog }}
+{% endfor %}
+
+---
+*This PR was created by [release-plz](https://github.com/MarcoIeni/release-plz)*
+"""
 
 # Publishing
 publish = true


### PR DESCRIPTION
## Summary

Fixes the issue where release-plz creates PRs with empty changelog sections and GitHub releases without descriptions.

## Problem

- Release PRs created by release-plz show "empty changelog" even though CHANGELOG.md has content
- GitHub releases created by release-plz have no description/body
- Similar issue observed in langfuse-client-base repo (see [PR #30](https://github.com/genai-rs/langfuse-client-base/pull/30) and [v0.2.1 release](https://github.com/genai-rs/langfuse-client-base/releases/tag/v0.2.1))

## Solution

Added two templates to release-plz.toml:
1. **`git_release_body`**: Template for GitHub release descriptions
   - Shows "What's Changed" section with changelog content
   - Includes "Full Changelog" link comparing versions
   
2. **`pr_body`**: Template for release PR descriptions  
   - Shows package updates with version changes
   - Displays full changelog for each package
   - Adds attribution to release-plz

## Test Plan

- [x] Updated release-plz.toml with proper templates
- [ ] Next release PR should show changelog content properly
- [ ] Next GitHub release should have proper description

## Related Issues

- Example of empty changelog: https://github.com/genai-rs/langfuse-client-base/pull/30
- Example of empty release: https://github.com/genai-rs/langfuse-client-base/releases/tag/v0.2.1