### PR TITLE
feat: add MSRV label for minimum supported Rust version tracking

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -113,3 +113,7 @@ labels:
   - name: ci
     color: FFFF00
     description: Continuous Integration
+  
+  - name: msrv
+    color: FF6B35
+    description: Minimum Supported Rust Version changes


### PR DESCRIPTION
## Summary

Adds the MSRV (Minimum Supported Rust Version) label to match the labeling system used in [langfuse-client-base](https://github.com/genai-rs/langfuse-client-base).

## Changes

- **New label**: `msrv` with orange color (#FF6B35)
- **Description**: "Minimum Supported Rust Version changes"
- **Purpose**: Track PRs that affect the minimum supported Rust version

## Benefits

1. **Consistency**: Matches labeling between langfuse-ergonomic and langfuse-client-base
2. **Visibility**: Easy identification of MSRV-related changes
3. **Release Planning**: Helps identify breaking changes that affect supported Rust versions

## Usage

This label can be applied to:
- PRs that bump minimum Rust version requirements
- Changes to Cargo.toml rust-version field
- Use of new language features requiring newer Rust versions

## Test Plan

- [x] Added MSRV label definition to .github/settings.yml
- [ ] GitHub Settings app should create the label automatically
- [ ] Label should appear in repository labels list