### PR TITLE
feat: update release-plz config to match langfuse-client-base

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,16 +11,15 @@ git_tag_enable = true
 
 # Git release body template - ensures GitHub releases have proper content
 git_release_body = """
-## What's Changed
-
 {{ changelog }}
 
-**Full Changelog**: https://github.com/genai-rs/langfuse-ergonomic/compare/{{ previous_version }}...{{ version }}
+**Full Changelog**: {{ remote.compare_url }}
 """
 
 # PR settings
 pr_labels = ["release"]
 pr_draft = false
+pr_name = "chore: release version {{version}}"
 
 # PR body template - ensures PR descriptions show the changelog
 pr_body = """


### PR DESCRIPTION
## Summary

Updates our release-plz.toml configuration to match langfuse-client-base, ensuring consistent release formatting and proper comparison links between releases.

## Changes

### Git Release Body Template
- **Before**: Hardcoded repository URL in comparison link
- **After**: Use `{{ remote.compare_url }}` for dynamic GitHub comparison links
- **Benefit**: Automatic, proper comparison URLs between releases

### PR Naming
- **Added**: `pr_name = "chore: release version {{version}}"`
- **Benefit**: Consistent PR naming across both repositories

### Template Simplification  
- **Removed**: "What's Changed" header to match langfuse-client-base format
- **Result**: Cleaner release notes that focus on changelog content

## Example Output

With these changes, GitHub releases will show:
```
### Fixed
- bug fix descriptions

### Added  
- new feature descriptions

**Full Changelog**: https://github.com/genai-rs/langfuse-ergonomic/compare/v0.2.0...v0.2.1
```

## Benefits

1. **Consistency**: Matches langfuse-client-base release format exactly
2. **Dynamic Links**: Comparison URLs work correctly regardless of version
3. **Clean Format**: Simplified templates focus on changelog content
4. **Maintenance**: Easier to maintain consistent configs across repos

## Test Plan

- [x] Updated release-plz.toml with new templates
- [ ] Next release should show proper comparison links
- [ ] PR naming should follow new template

## Related

- Reference config: https://github.com/genai-rs/langfuse-client-base/blob/main/release-plz.toml