### PR TITLE
feat: add Trace URLs and BYO IDs support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 thiserror = "1.0"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1.10", features = ["v4", "serde"] }
+uuid = { version = "1.10", features = ["v4", "v5", "serde"] }
 url = "2.5"
 tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
@@ -76,6 +76,10 @@ path = "examples/batch_ingestion.rs"
 [[example]]
 name = "self_hosted"  
 path = "examples/self_hosted.rs"
+
+[[example]]
+name = "trace_urls_byo_ids"
+path = "examples/trace_urls_byo_ids.rs"
 
 
 [features]

--- a/examples/trace_urls_byo_ids.rs
+++ b/examples/trace_urls_byo_ids.rs
@@ -1,0 +1,193 @@
+//! Example demonstrating Trace URLs and Bring Your Own IDs
+//!
+//! This example shows how to:
+//! - Get Langfuse URLs for created traces
+//! - Use custom/deterministic IDs for traces and observations
+//! - Generate reproducible IDs from seeds
+//! - Create hierarchical ID structures
+
+use langfuse_ergonomic::{IdGenerator, LangfuseClient};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize from environment variables
+    dotenvy::dotenv().ok();
+    
+    let client = LangfuseClient::from_env()?;
+    
+    println!("🔗 Demonstrating Trace URLs and custom IDs...\n");
+    
+    // Example 1: Create a trace with auto-generated ID and get its URL
+    println!("1️⃣ Creating trace with auto-generated ID:");
+    let response = client.trace()
+        .name("Auto ID Trace")
+        .input(json!({
+            "message": "This trace has an auto-generated ID"
+        }))
+        .tags(vec!["auto-id".to_string()])
+        .call()
+        .await?;
+    
+    println!("   Trace ID: {}", response.id);
+    println!("   Trace URL: {}", response.url());
+    println!();
+    
+    // Example 2: Create a trace with a custom ID
+    println!("2️⃣ Creating trace with custom ID:");
+    let custom_id = "my-custom-trace-12345";
+    let response = client.trace()
+        .id(custom_id.to_string())
+        .name("Custom ID Trace")
+        .input(json!({
+            "message": "This trace has a custom ID"
+        }))
+        .tags(vec!["custom-id".to_string()])
+        .call()
+        .await?;
+    
+    println!("   Trace ID: {}", response.id);
+    println!("   Trace URL: {}", response.url());
+    println!();
+    
+    // Example 3: Generate deterministic IDs from seeds
+    println!("3️⃣ Generating deterministic IDs from seeds:");
+    
+    let seed = "user-123:session-456:request-789";
+    let deterministic_id = IdGenerator::from_seed(seed);
+    
+    println!("   Seed: {}", seed);
+    println!("   Generated ID: {}", deterministic_id);
+    
+    // Create trace with deterministic ID
+    let response = client.trace()
+        .id(deterministic_id.clone())
+        .name("Deterministic ID Trace")
+        .input(json!({
+            "seed": seed,
+            "message": "This ID is reproducible from the seed"
+        }))
+        .tags(vec!["deterministic-id".to_string()])
+        .call()
+        .await?;
+    
+    println!("   Trace URL: {}", response.url());
+    
+    // Running this again with the same seed would produce the same ID
+    let same_id = IdGenerator::from_seed(seed);
+    println!("   Verified: Same seed produces same ID: {}", deterministic_id == same_id);
+    println!();
+    
+    // Example 4: Hierarchical IDs for related observations
+    println!("4️⃣ Creating hierarchical IDs for related observations:");
+    
+    let base_seed = "workflow-execution-2024";
+    let trace_id = IdGenerator::from_components(&[base_seed, "trace"]);
+    
+    let response = client.trace()
+        .id(trace_id.clone())
+        .name("Workflow Trace")
+        .input(json!({
+            "workflow": "data-processing",
+            "run_id": base_seed
+        }))
+        .call()
+        .await?;
+    
+    println!("   Trace ID: {}", trace_id);
+    println!("   Trace URL: {}", response.url());
+    
+    // Create related spans with hierarchical IDs
+    let span1_id = IdGenerator::from_components(&[base_seed, "span", "data-fetch"]);
+    let span2_id = IdGenerator::from_components(&[base_seed, "span", "data-process"]);
+    
+    let span1 = client.span()
+        .trace_id(trace_id.clone())
+        .id(span1_id.clone())
+        .name("Fetch Data")
+        .input(json!({ "source": "database" }))
+        .call()
+        .await?;
+    
+    println!("   └─ Span 1 ID: {}", span1);
+    
+    let span2 = client.span()
+        .trace_id(trace_id.clone())
+        .id(span2_id.clone())
+        .parent_observation_id(span1_id.clone())
+        .name("Process Data")
+        .input(json!({ "operation": "transform" }))
+        .call()
+        .await?;
+    
+    println!("      └─ Span 2 ID: {}", span2);
+    println!();
+    
+    // Example 5: Hash-based IDs for simple cases
+    println!("5️⃣ Using hash-based IDs:");
+    
+    let hash_seed = "simple-seed-123";
+    let hash_id = IdGenerator::from_hash(hash_seed);
+    
+    println!("   Hash seed: {}", hash_seed);
+    println!("   Hash ID: {}", hash_id);
+    
+    // This is useful when you want shorter, simpler IDs
+    let response = client.trace()
+        .id(hash_id.clone())
+        .name("Hash ID Trace")
+        .metadata(json!({
+            "id_type": "hash",
+            "seed": hash_seed
+        }))
+        .call()
+        .await?;
+    
+    println!("   Trace URL: {}", response.url());
+    println!();
+    
+    // Example 6: Idempotent trace creation
+    println!("6️⃣ Demonstrating idempotent trace creation:");
+    
+    let idempotent_seed = format!("daily-report:{}", chrono::Utc::now().format("%Y-%m-%d"));
+    let idempotent_id = IdGenerator::from_seed(&idempotent_seed);
+    
+    println!("   Creating trace with ID from seed: {}", idempotent_seed);
+    
+    // First creation
+    let response1 = client.trace()
+        .id(idempotent_id.clone())
+        .name("Daily Report")
+        .metadata(json!({
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "attempt": 1
+        }))
+        .call()
+        .await?;
+    
+    println!("   First creation - URL: {}", response1.url());
+    
+    // Second creation with same ID (will update the existing trace)
+    let response2 = client.trace()
+        .id(idempotent_id.clone())
+        .name("Daily Report (Updated)")
+        .metadata(json!({
+            "updated_at": chrono::Utc::now().to_rfc3339(),
+            "attempt": 2
+        }))
+        .call()
+        .await?;
+    
+    println!("   Second creation - URL: {}", response2.url());
+    println!("   Same URL: {}", response1.url() == response2.url());
+    println!();
+    
+    println!("✅ All examples completed successfully!");
+    println!("\n📝 Summary:");
+    println!("   - Traces automatically provide their Langfuse URLs via .url()");
+    println!("   - Custom IDs enable deterministic and idempotent trace creation");
+    println!("   - Seed-based IDs ensure reproducibility across runs");
+    println!("   - Hierarchical IDs help organize related observations");
+    
+    Ok(())
+}

--- a/examples/trace_urls_byo_ids.rs
+++ b/examples/trace_urls_byo_ids.rs
@@ -13,14 +13,15 @@ use serde_json::json;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize from environment variables
     dotenvy::dotenv().ok();
-    
+
     let client = LangfuseClient::from_env()?;
-    
+
     println!("🔗 Demonstrating Trace URLs and custom IDs...\n");
-    
+
     // Example 1: Create a trace with auto-generated ID and get its URL
     println!("1️⃣ Creating trace with auto-generated ID:");
-    let response = client.trace()
+    let response = client
+        .trace()
         .name("Auto ID Trace")
         .input(json!({
             "message": "This trace has an auto-generated ID"
@@ -28,15 +29,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .tags(vec!["auto-id".to_string()])
         .call()
         .await?;
-    
+
     println!("   Trace ID: {}", response.id);
     println!("   Trace URL: {}", response.url());
     println!();
-    
+
     // Example 2: Create a trace with a custom ID
     println!("2️⃣ Creating trace with custom ID:");
     let custom_id = "my-custom-trace-12345";
-    let response = client.trace()
+    let response = client
+        .trace()
         .id(custom_id.to_string())
         .name("Custom ID Trace")
         .input(json!({
@@ -45,22 +47,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .tags(vec!["custom-id".to_string()])
         .call()
         .await?;
-    
+
     println!("   Trace ID: {}", response.id);
     println!("   Trace URL: {}", response.url());
     println!();
-    
+
     // Example 3: Generate deterministic IDs from seeds
     println!("3️⃣ Generating deterministic IDs from seeds:");
-    
+
     let seed = "user-123:session-456:request-789";
     let deterministic_id = IdGenerator::from_seed(seed);
-    
+
     println!("   Seed: {}", seed);
     println!("   Generated ID: {}", deterministic_id);
-    
+
     // Create trace with deterministic ID
-    let response = client.trace()
+    let response = client
+        .trace()
         .id(deterministic_id.clone())
         .name("Deterministic ID Trace")
         .input(json!({
@@ -70,21 +73,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .tags(vec!["deterministic-id".to_string()])
         .call()
         .await?;
-    
+
     println!("   Trace URL: {}", response.url());
-    
+
     // Running this again with the same seed would produce the same ID
     let same_id = IdGenerator::from_seed(seed);
-    println!("   Verified: Same seed produces same ID: {}", deterministic_id == same_id);
+    println!(
+        "   Verified: Same seed produces same ID: {}",
+        deterministic_id == same_id
+    );
     println!();
-    
+
     // Example 4: Hierarchical IDs for related observations
     println!("4️⃣ Creating hierarchical IDs for related observations:");
-    
+
     let base_seed = "workflow-execution-2024";
     let trace_id = IdGenerator::from_components(&[base_seed, "trace"]);
-    
-    let response = client.trace()
+
+    let response = client
+        .trace()
         .id(trace_id.clone())
         .name("Workflow Trace")
         .input(json!({
@@ -93,25 +100,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .call()
         .await?;
-    
+
     println!("   Trace ID: {}", trace_id);
     println!("   Trace URL: {}", response.url());
-    
+
     // Create related spans with hierarchical IDs
     let span1_id = IdGenerator::from_components(&[base_seed, "span", "data-fetch"]);
     let span2_id = IdGenerator::from_components(&[base_seed, "span", "data-process"]);
-    
-    let span1 = client.span()
+
+    let span1 = client
+        .span()
         .trace_id(trace_id.clone())
         .id(span1_id.clone())
         .name("Fetch Data")
         .input(json!({ "source": "database" }))
         .call()
         .await?;
-    
+
     println!("   └─ Span 1 ID: {}", span1);
-    
-    let span2 = client.span()
+
+    let span2 = client
+        .span()
         .trace_id(trace_id.clone())
         .id(span2_id.clone())
         .parent_observation_id(span1_id.clone())
@@ -119,21 +128,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .input(json!({ "operation": "transform" }))
         .call()
         .await?;
-    
+
     println!("      └─ Span 2 ID: {}", span2);
     println!();
-    
+
     // Example 5: Hash-based IDs for simple cases
     println!("5️⃣ Using hash-based IDs:");
-    
+
     let hash_seed = "simple-seed-123";
     let hash_id = IdGenerator::from_hash(hash_seed);
-    
+
     println!("   Hash seed: {}", hash_seed);
     println!("   Hash ID: {}", hash_id);
-    
+
     // This is useful when you want shorter, simpler IDs
-    let response = client.trace()
+    let response = client
+        .trace()
         .id(hash_id.clone())
         .name("Hash ID Trace")
         .metadata(json!({
@@ -142,20 +152,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .call()
         .await?;
-    
+
     println!("   Trace URL: {}", response.url());
     println!();
-    
+
     // Example 6: Idempotent trace creation
     println!("6️⃣ Demonstrating idempotent trace creation:");
-    
+
     let idempotent_seed = format!("daily-report:{}", chrono::Utc::now().format("%Y-%m-%d"));
     let idempotent_id = IdGenerator::from_seed(&idempotent_seed);
-    
+
     println!("   Creating trace with ID from seed: {}", idempotent_seed);
-    
+
     // First creation
-    let response1 = client.trace()
+    let response1 = client
+        .trace()
         .id(idempotent_id.clone())
         .name("Daily Report")
         .metadata(json!({
@@ -164,11 +175,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .call()
         .await?;
-    
+
     println!("   First creation - URL: {}", response1.url());
-    
+
     // Second creation with same ID (will update the existing trace)
-    let response2 = client.trace()
+    let response2 = client
+        .trace()
         .id(idempotent_id.clone())
         .name("Daily Report (Updated)")
         .metadata(json!({
@@ -177,17 +189,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }))
         .call()
         .await?;
-    
+
     println!("   Second creation - URL: {}", response2.url());
     println!("   Same URL: {}", response1.url() == response2.url());
     println!();
-    
+
     println!("✅ All examples completed successfully!");
     println!("\n📝 Summary:");
     println!("   - Traces automatically provide their Langfuse URLs via .url()");
     println!("   - Custom IDs enable deterministic and idempotent trace creation");
     println!("   - Seed-based IDs ensure reproducibility across runs");
     println!("   - Hierarchical IDs help organize related observations");
-    
+
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ pub mod traces;
 pub use batcher::{BatchEvent, Batcher, BatcherConfig};
 pub use client::LangfuseClient;
 pub use error::{Error, EventError, IngestionResponse, Result};
-pub use traces::TraceResponse;
+pub use traces::{IdGenerator, TraceResponse};

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -36,14 +36,14 @@ impl IdGenerator {
         let namespace = Uuid::NAMESPACE_OID;
         Uuid::new_v5(&namespace, seed.as_bytes()).to_string()
     }
-    
+
     /// Generate a deterministic ID from multiple components
     /// Useful for creating hierarchical IDs (e.g., trace -> span -> event)
     pub fn from_components(components: &[&str]) -> String {
         let combined = components.join(":");
         Self::from_seed(&combined)
     }
-    
+
     /// Generate a deterministic ID using a hash-based approach
     /// Alternative to UUID v5 for simpler use cases
     pub fn from_hash(seed: &str) -> String {
@@ -118,7 +118,7 @@ impl LangfuseClient {
 
         ingestion_api::ingestion_batch(self.configuration(), batch_request)
             .await
-            .map(|_| TraceResponse { 
+            .map(|_| TraceResponse {
                 id: trace_id,
                 base_url: self.configuration().base_path.clone(),
             })

--- a/tests/trace_urls_test.rs
+++ b/tests/trace_urls_test.rs
@@ -7,21 +7,46 @@ use mockito::Server;
 fn test_trace_url_generation() {
     // Test various base URL formats
     let test_cases = vec![
-        ("https://cloud.langfuse.com", "test-123", "https://cloud.langfuse.com/trace/test-123"),
-        ("https://cloud.langfuse.com/", "test-456", "https://cloud.langfuse.com/trace/test-456"),
-        ("https://cloud.langfuse.com/api", "test-789", "https://cloud.langfuse.com/trace/test-789"),
-        ("http://localhost:3000", "local-123", "http://localhost:3000/trace/local-123"),
-        ("http://localhost:3000/api", "local-456", "http://localhost:3000/trace/local-456"),
+        (
+            "https://cloud.langfuse.com",
+            "test-123",
+            "https://cloud.langfuse.com/trace/test-123",
+        ),
+        (
+            "https://cloud.langfuse.com/",
+            "test-456",
+            "https://cloud.langfuse.com/trace/test-456",
+        ),
+        (
+            "https://cloud.langfuse.com/api",
+            "test-789",
+            "https://cloud.langfuse.com/trace/test-789",
+        ),
+        (
+            "http://localhost:3000",
+            "local-123",
+            "http://localhost:3000/trace/local-123",
+        ),
+        (
+            "http://localhost:3000/api",
+            "local-456",
+            "http://localhost:3000/trace/local-456",
+        ),
     ];
-    
+
     for (base_url, trace_id, expected_url) in test_cases {
         let response = langfuse_ergonomic::TraceResponse {
             id: trace_id.to_string(),
             base_url: base_url.to_string(),
         };
-        
-        assert_eq!(response.url(), expected_url, 
-            "Failed for base_url: {}, trace_id: {}", base_url, trace_id);
+
+        assert_eq!(
+            response.url(),
+            expected_url,
+            "Failed for base_url: {}, trace_id: {}",
+            base_url,
+            trace_id
+        );
     }
 }
 
@@ -31,9 +56,9 @@ fn test_deterministic_id_generation() {
     let seed = "test-seed-123";
     let id1 = IdGenerator::from_seed(seed);
     let id2 = IdGenerator::from_seed(seed);
-    
+
     assert_eq!(id1, id2, "Same seed should produce same ID");
-    
+
     // Test that different seeds produce different IDs
     let id3 = IdGenerator::from_seed("different-seed");
     assert_ne!(id1, id3, "Different seeds should produce different IDs");
@@ -44,16 +69,19 @@ fn test_component_based_id_generation() {
     // Test hierarchical ID generation
     let components = vec!["user-123", "session-456", "request-789"];
     let id1 = IdGenerator::from_components(&components);
-    
+
     // Same components should produce same ID
     let id2 = IdGenerator::from_components(&components);
     assert_eq!(id1, id2, "Same components should produce same ID");
-    
+
     // Different order should produce different ID
     let components_reordered = vec!["session-456", "user-123", "request-789"];
     let id3 = IdGenerator::from_components(&components_reordered);
-    assert_ne!(id1, id3, "Different component order should produce different ID");
-    
+    assert_ne!(
+        id1, id3,
+        "Different component order should produce different ID"
+    );
+
     // Different components should produce different ID
     let components_different = vec!["user-999", "session-888", "request-777"];
     let id4 = IdGenerator::from_components(&components_different);
@@ -66,16 +94,22 @@ fn test_hash_based_id_generation() {
     let seed = "hash-seed-123";
     let id1 = IdGenerator::from_hash(seed);
     let id2 = IdGenerator::from_hash(seed);
-    
+
     assert_eq!(id1, id2, "Same seed should produce same hash ID");
-    
+
     // Hash IDs should be 16 hex characters
     assert_eq!(id1.len(), 16, "Hash ID should be 16 characters");
-    assert!(id1.chars().all(|c| c.is_ascii_hexdigit()), "Hash ID should be hexadecimal");
-    
+    assert!(
+        id1.chars().all(|c| c.is_ascii_hexdigit()),
+        "Hash ID should be hexadecimal"
+    );
+
     // Different seeds produce different hash IDs
     let id3 = IdGenerator::from_hash("different-hash-seed");
-    assert_ne!(id1, id3, "Different seeds should produce different hash IDs");
+    assert_ne!(
+        id1, id3,
+        "Different seeds should produce different hash IDs"
+    );
 }
 
 #[test]
@@ -83,28 +117,34 @@ fn test_uuid_v5_format() {
     // Test that from_seed produces valid UUID v5 format
     let seed = "uuid-test-seed";
     let id = IdGenerator::from_seed(seed);
-    
+
     // UUID format: 8-4-4-4-12 hex characters with hyphens
     let parts: Vec<&str> = id.split('-').collect();
-    assert_eq!(parts.len(), 5, "UUID should have 5 parts separated by hyphens");
-    
+    assert_eq!(
+        parts.len(),
+        5,
+        "UUID should have 5 parts separated by hyphens"
+    );
+
     assert_eq!(parts[0].len(), 8, "First part should be 8 characters");
     assert_eq!(parts[1].len(), 4, "Second part should be 4 characters");
     assert_eq!(parts[2].len(), 4, "Third part should be 4 characters");
     assert_eq!(parts[3].len(), 4, "Fourth part should be 4 characters");
     assert_eq!(parts[4].len(), 12, "Fifth part should be 12 characters");
-    
+
     // All parts should be hexadecimal
     for part in parts {
-        assert!(part.chars().all(|c| c.is_ascii_hexdigit()), 
-            "UUID parts should be hexadecimal");
+        assert!(
+            part.chars().all(|c| c.is_ascii_hexdigit()),
+            "UUID parts should be hexadecimal"
+        );
     }
 }
 
 #[tokio::test]
 async fn test_trace_with_custom_id() {
     let mut server = Server::new_async().await;
-    
+
     // Mock the ingestion endpoint
     let mock = server
         .mock("POST", "/api/public/ingestion")
@@ -113,36 +153,37 @@ async fn test_trace_with_custom_id() {
         .with_body(r#"{"successes": [], "errors": []}"#)
         .create_async()
         .await;
-    
+
     let client = LangfuseClient::builder()
         .public_key("pk-test")
         .secret_key("sk-test")
         .base_url(server.url())
         .build();
-    
+
     // Create trace with custom ID
     let custom_id = "my-custom-trace-id";
-    let response = client.trace()
+    let response = client
+        .trace()
         .id(custom_id.to_string())
         .name("Test Trace")
         .call()
         .await
         .unwrap();
-    
+
     // Verify the response contains our custom ID
     assert_eq!(response.id, custom_id);
-    
+
     // Verify the URL is correctly generated
     let expected_url = format!("{}/trace/{}", server.url(), custom_id);
     assert_eq!(response.url(), expected_url);
-    
+
     mock.assert_async().await;
 }
 
 #[tokio::test]
 async fn test_trace_with_seed_based_id() {
     let mut server = Server::new_async().await;
-    
+
     // Mock the ingestion endpoint
     let mock = server
         .mock("POST", "/api/public/ingestion")
@@ -151,39 +192,40 @@ async fn test_trace_with_seed_based_id() {
         .with_body(r#"{"successes": [], "errors": []}"#)
         .create_async()
         .await;
-    
+
     let client = LangfuseClient::builder()
         .public_key("pk-test")
         .secret_key("sk-test")
         .base_url(server.url())
         .build();
-    
+
     // Generate deterministic ID from seed
     let seed = "test-seed-for-trace";
     let deterministic_id = IdGenerator::from_seed(seed);
-    
+
     // Create trace with deterministic ID
-    let response = client.trace()
+    let response = client
+        .trace()
         .id(deterministic_id.clone())
         .name("Deterministic Trace")
         .call()
         .await
         .unwrap();
-    
+
     // Verify the response contains our deterministic ID
     assert_eq!(response.id, deterministic_id);
-    
+
     // Verify reproducibility - same seed should give same ID
     let same_id = IdGenerator::from_seed(seed);
     assert_eq!(deterministic_id, same_id);
-    
+
     mock.assert_async().await;
 }
 
 #[tokio::test]
 async fn test_hierarchical_observations() {
     let mut server = Server::new_async().await;
-    
+
     // Mock the ingestion endpoint for multiple calls
     let mock = server
         .mock("POST", "/api/public/ingestion")
@@ -193,42 +235,45 @@ async fn test_hierarchical_observations() {
         .expect(3) // Expect 3 calls: trace, span1, span2
         .create_async()
         .await;
-    
+
     let client = LangfuseClient::builder()
         .public_key("pk-test")
         .secret_key("sk-test")
         .base_url(server.url())
         .build();
-    
+
     // Create hierarchical IDs
     let base_seed = "workflow-123";
     let trace_id = IdGenerator::from_components(&[base_seed, "trace"]);
     let span1_id = IdGenerator::from_components(&[base_seed, "span", "step1"]);
     let span2_id = IdGenerator::from_components(&[base_seed, "span", "step2"]);
-    
+
     // Create trace
-    let trace_response = client.trace()
+    let trace_response = client
+        .trace()
         .id(trace_id.clone())
         .name("Workflow Trace")
         .call()
         .await
         .unwrap();
-    
+
     assert_eq!(trace_response.id, trace_id);
-    
+
     // Create first span
-    let span1_response = client.span()
+    let span1_response = client
+        .span()
         .trace_id(trace_id.clone())
         .id(span1_id.clone())
         .name("Step 1")
         .call()
         .await
         .unwrap();
-    
+
     assert_eq!(span1_response, span1_id);
-    
+
     // Create nested span
-    let span2_response = client.span()
+    let span2_response = client
+        .span()
         .trace_id(trace_id.clone())
         .id(span2_id.clone())
         .parent_observation_id(span1_id.clone())
@@ -236,13 +281,22 @@ async fn test_hierarchical_observations() {
         .call()
         .await
         .unwrap();
-    
+
     assert_eq!(span2_response, span2_id);
-    
+
     // Verify all IDs are deterministic and reproducible
-    assert_eq!(trace_id, IdGenerator::from_components(&[base_seed, "trace"]));
-    assert_eq!(span1_id, IdGenerator::from_components(&[base_seed, "span", "step1"]));
-    assert_eq!(span2_id, IdGenerator::from_components(&[base_seed, "span", "step2"]));
-    
+    assert_eq!(
+        trace_id,
+        IdGenerator::from_components(&[base_seed, "trace"])
+    );
+    assert_eq!(
+        span1_id,
+        IdGenerator::from_components(&[base_seed, "span", "step1"])
+    );
+    assert_eq!(
+        span2_id,
+        IdGenerator::from_components(&[base_seed, "span", "step2"])
+    );
+
     mock.assert_async().await;
 }

--- a/tests/trace_urls_test.rs
+++ b/tests/trace_urls_test.rs
@@ -1,0 +1,248 @@
+//! Tests for Trace URLs and BYO IDs functionality
+
+use langfuse_ergonomic::{IdGenerator, LangfuseClient};
+use mockito::Server;
+
+#[test]
+fn test_trace_url_generation() {
+    // Test various base URL formats
+    let test_cases = vec![
+        ("https://cloud.langfuse.com", "test-123", "https://cloud.langfuse.com/trace/test-123"),
+        ("https://cloud.langfuse.com/", "test-456", "https://cloud.langfuse.com/trace/test-456"),
+        ("https://cloud.langfuse.com/api", "test-789", "https://cloud.langfuse.com/trace/test-789"),
+        ("http://localhost:3000", "local-123", "http://localhost:3000/trace/local-123"),
+        ("http://localhost:3000/api", "local-456", "http://localhost:3000/trace/local-456"),
+    ];
+    
+    for (base_url, trace_id, expected_url) in test_cases {
+        let response = langfuse_ergonomic::TraceResponse {
+            id: trace_id.to_string(),
+            base_url: base_url.to_string(),
+        };
+        
+        assert_eq!(response.url(), expected_url, 
+            "Failed for base_url: {}, trace_id: {}", base_url, trace_id);
+    }
+}
+
+#[test]
+fn test_deterministic_id_generation() {
+    // Test that same seed produces same ID
+    let seed = "test-seed-123";
+    let id1 = IdGenerator::from_seed(seed);
+    let id2 = IdGenerator::from_seed(seed);
+    
+    assert_eq!(id1, id2, "Same seed should produce same ID");
+    
+    // Test that different seeds produce different IDs
+    let id3 = IdGenerator::from_seed("different-seed");
+    assert_ne!(id1, id3, "Different seeds should produce different IDs");
+}
+
+#[test]
+fn test_component_based_id_generation() {
+    // Test hierarchical ID generation
+    let components = vec!["user-123", "session-456", "request-789"];
+    let id1 = IdGenerator::from_components(&components);
+    
+    // Same components should produce same ID
+    let id2 = IdGenerator::from_components(&components);
+    assert_eq!(id1, id2, "Same components should produce same ID");
+    
+    // Different order should produce different ID
+    let components_reordered = vec!["session-456", "user-123", "request-789"];
+    let id3 = IdGenerator::from_components(&components_reordered);
+    assert_ne!(id1, id3, "Different component order should produce different ID");
+    
+    // Different components should produce different ID
+    let components_different = vec!["user-999", "session-888", "request-777"];
+    let id4 = IdGenerator::from_components(&components_different);
+    assert_ne!(id1, id4, "Different components should produce different ID");
+}
+
+#[test]
+fn test_hash_based_id_generation() {
+    // Test hash-based ID generation
+    let seed = "hash-seed-123";
+    let id1 = IdGenerator::from_hash(seed);
+    let id2 = IdGenerator::from_hash(seed);
+    
+    assert_eq!(id1, id2, "Same seed should produce same hash ID");
+    
+    // Hash IDs should be 16 hex characters
+    assert_eq!(id1.len(), 16, "Hash ID should be 16 characters");
+    assert!(id1.chars().all(|c| c.is_ascii_hexdigit()), "Hash ID should be hexadecimal");
+    
+    // Different seeds produce different hash IDs
+    let id3 = IdGenerator::from_hash("different-hash-seed");
+    assert_ne!(id1, id3, "Different seeds should produce different hash IDs");
+}
+
+#[test]
+fn test_uuid_v5_format() {
+    // Test that from_seed produces valid UUID v5 format
+    let seed = "uuid-test-seed";
+    let id = IdGenerator::from_seed(seed);
+    
+    // UUID format: 8-4-4-4-12 hex characters with hyphens
+    let parts: Vec<&str> = id.split('-').collect();
+    assert_eq!(parts.len(), 5, "UUID should have 5 parts separated by hyphens");
+    
+    assert_eq!(parts[0].len(), 8, "First part should be 8 characters");
+    assert_eq!(parts[1].len(), 4, "Second part should be 4 characters");
+    assert_eq!(parts[2].len(), 4, "Third part should be 4 characters");
+    assert_eq!(parts[3].len(), 4, "Fourth part should be 4 characters");
+    assert_eq!(parts[4].len(), 12, "Fifth part should be 12 characters");
+    
+    // All parts should be hexadecimal
+    for part in parts {
+        assert!(part.chars().all(|c| c.is_ascii_hexdigit()), 
+            "UUID parts should be hexadecimal");
+    }
+}
+
+#[tokio::test]
+async fn test_trace_with_custom_id() {
+    let mut server = Server::new_async().await;
+    
+    // Mock the ingestion endpoint
+    let mock = server
+        .mock("POST", "/api/public/ingestion")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"successes": [], "errors": []}"#)
+        .create_async()
+        .await;
+    
+    let client = LangfuseClient::builder()
+        .public_key("pk-test")
+        .secret_key("sk-test")
+        .base_url(server.url())
+        .build();
+    
+    // Create trace with custom ID
+    let custom_id = "my-custom-trace-id";
+    let response = client.trace()
+        .id(custom_id.to_string())
+        .name("Test Trace")
+        .call()
+        .await
+        .unwrap();
+    
+    // Verify the response contains our custom ID
+    assert_eq!(response.id, custom_id);
+    
+    // Verify the URL is correctly generated
+    let expected_url = format!("{}/trace/{}", server.url(), custom_id);
+    assert_eq!(response.url(), expected_url);
+    
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_trace_with_seed_based_id() {
+    let mut server = Server::new_async().await;
+    
+    // Mock the ingestion endpoint
+    let mock = server
+        .mock("POST", "/api/public/ingestion")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"successes": [], "errors": []}"#)
+        .create_async()
+        .await;
+    
+    let client = LangfuseClient::builder()
+        .public_key("pk-test")
+        .secret_key("sk-test")
+        .base_url(server.url())
+        .build();
+    
+    // Generate deterministic ID from seed
+    let seed = "test-seed-for-trace";
+    let deterministic_id = IdGenerator::from_seed(seed);
+    
+    // Create trace with deterministic ID
+    let response = client.trace()
+        .id(deterministic_id.clone())
+        .name("Deterministic Trace")
+        .call()
+        .await
+        .unwrap();
+    
+    // Verify the response contains our deterministic ID
+    assert_eq!(response.id, deterministic_id);
+    
+    // Verify reproducibility - same seed should give same ID
+    let same_id = IdGenerator::from_seed(seed);
+    assert_eq!(deterministic_id, same_id);
+    
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_hierarchical_observations() {
+    let mut server = Server::new_async().await;
+    
+    // Mock the ingestion endpoint for multiple calls
+    let mock = server
+        .mock("POST", "/api/public/ingestion")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"successes": [], "errors": []}"#)
+        .expect(3) // Expect 3 calls: trace, span1, span2
+        .create_async()
+        .await;
+    
+    let client = LangfuseClient::builder()
+        .public_key("pk-test")
+        .secret_key("sk-test")
+        .base_url(server.url())
+        .build();
+    
+    // Create hierarchical IDs
+    let base_seed = "workflow-123";
+    let trace_id = IdGenerator::from_components(&[base_seed, "trace"]);
+    let span1_id = IdGenerator::from_components(&[base_seed, "span", "step1"]);
+    let span2_id = IdGenerator::from_components(&[base_seed, "span", "step2"]);
+    
+    // Create trace
+    let trace_response = client.trace()
+        .id(trace_id.clone())
+        .name("Workflow Trace")
+        .call()
+        .await
+        .unwrap();
+    
+    assert_eq!(trace_response.id, trace_id);
+    
+    // Create first span
+    let span1_response = client.span()
+        .trace_id(trace_id.clone())
+        .id(span1_id.clone())
+        .name("Step 1")
+        .call()
+        .await
+        .unwrap();
+    
+    assert_eq!(span1_response, span1_id);
+    
+    // Create nested span
+    let span2_response = client.span()
+        .trace_id(trace_id.clone())
+        .id(span2_id.clone())
+        .parent_observation_id(span1_id.clone())
+        .name("Step 2")
+        .call()
+        .await
+        .unwrap();
+    
+    assert_eq!(span2_response, span2_id);
+    
+    // Verify all IDs are deterministic and reproducible
+    assert_eq!(trace_id, IdGenerator::from_components(&[base_seed, "trace"]));
+    assert_eq!(span1_id, IdGenerator::from_components(&[base_seed, "span", "step1"]));
+    assert_eq!(span2_id, IdGenerator::from_components(&[base_seed, "span", "step2"]));
+    
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
This PR implements Trace URLs and Bring Your Own IDs (BYO IDs) functionality, addressing item #5 from the ChatGPT-5 review feedback.

## Features Implemented

### ✅ Trace URLs
- Added `url()` method to `TraceResponse` that generates the Langfuse web URL for a trace
- Handles different base URL formats (with/without /api suffix)
- Example: `https://cloud.langfuse.com/trace/{trace-id}`

### ✅ Custom/Deterministic IDs
- Full support for custom IDs in traces, spans, generations, and events
- New `IdGenerator` utility with three methods:
  - `from_seed()`: Generates deterministic UUID v5 from a seed string
  - `from_components()`: Creates hierarchical IDs from component array
  - `from_hash()`: Simple hash-based ID generation

### Benefits
- **Idempotent Operations**: Same ID ensures updates instead of duplicates
- **Reproducible Testing**: Deterministic IDs from seeds for consistent test data
- **Direct Linking**: Get trace URLs immediately after creation
- **Hierarchical Organization**: Related observations can have structured IDs
- **External ID Integration**: Use your own ID scheme or integrate with external systems

## Example Usage

```rust
// Get trace URL
let response = client.trace()
    .name("My Trace")
    .call()
    .await?;
println!("View at: {}", response.url());

// Use custom ID
let response = client.trace()
    .id("my-custom-id-123")
    .name("Custom ID Trace")
    .call()
    .await?;

// Generate deterministic ID
let id = IdGenerator::from_seed("user-123:session-456");
let response = client.trace()
    .id(id)
    .name("Deterministic Trace")
    .call()
    .await?;
```

## Test Coverage
- Comprehensive test suite in `tests/trace_urls_test.rs`
- Tests for URL generation with various base URL formats
- Tests for all three ID generation methods
- Tests for hierarchical observation IDs
- Example in `examples/trace_urls_byo_ids.rs` demonstrating all features

## Breaking Changes
- `TraceResponse.base_url` is now public (was private)
- No other breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)