### PR TITLE
fix: align TLS features with reqwest dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ langfuse-client-base = "0.2"
 bon = "3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json"], default-features = false }
 thiserror = "1.0"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -88,6 +88,6 @@ path = "examples/trace_urls_byo_ids.rs"
 
 [features]
 default = ["rustls"]
-rustls = ["langfuse-client-base/rustls"]
-native-tls = ["langfuse-client-base/native-tls"]
+rustls = ["langfuse-client-base/rustls", "reqwest/rustls-tls"]
+native-tls = ["langfuse-client-base/native-tls", "reqwest/native-tls"]
 compression = ["reqwest/gzip", "reqwest/brotli", "reqwest/deflate"]


### PR DESCRIPTION
## Summary
Fixes TLS feature alignment so that reqwest uses the same TLS backend as selected by the crate features.

## Problem
Previously, reqwest was always built with `rustls-tls` regardless of which feature was selected, leading to:
- Unnecessary dependencies when using native-tls
- Potential conflicts between TLS implementations
- Larger binary sizes

## Solution
- Remove hardcoded `rustls-tls` from reqwest base dependencies
- Add proper feature flags that enable the corresponding reqwest TLS features
- Ensure both `langfuse-client-base` and `reqwest` use the same TLS backend

## Testing
- ✅ `cargo build --no-default-features --features rustls` works
- ✅ `cargo build --no-default-features --features native-tls` works
- ✅ Default build uses rustls

Based on feedback from code review.