### PR TITLE
fix: implement validate method and improve correctness

### DIFF
--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -848,17 +848,15 @@ impl Batcher {
                         // Try parsing as seconds (integer)
                         s.parse::<u64>().ok().or_else(|| {
                             // Try parsing as HTTP-date (RFC2616)
-                            chrono::DateTime::parse_from_rfc2822(s)
-                                .ok()
-                                .and_then(|dt| {
-                                    let now = chrono::Utc::now();
-                                    let retry_time = dt.with_timezone(&chrono::Utc);
-                                    if retry_time > now {
-                                        Some((retry_time - now).num_seconds() as u64)
-                                    } else {
-                                        None
-                                    }
-                                })
+                            chrono::DateTime::parse_from_rfc2822(s).ok().and_then(|dt| {
+                                let now = chrono::Utc::now();
+                                let retry_time = dt.with_timezone(&chrono::Utc);
+                                if retry_time > now {
+                                    Some((retry_time - now).num_seconds() as u64)
+                                } else {
+                                    None
+                                }
+                            })
                         })
                     })
                     .map(Duration::from_secs);

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -844,7 +844,23 @@ impl Batcher {
                     .headers()
                     .get("retry-after")
                     .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.parse::<u64>().ok())
+                    .and_then(|s| {
+                        // Try parsing as seconds (integer)
+                        s.parse::<u64>().ok().or_else(|| {
+                            // Try parsing as HTTP-date (RFC2616)
+                            chrono::DateTime::parse_from_rfc2822(s)
+                                .ok()
+                                .and_then(|dt| {
+                                    let now = chrono::Utc::now();
+                                    let retry_time = dt.with_timezone(&chrono::Utc);
+                                    if retry_time > now {
+                                        Some((retry_time - now).num_seconds() as u64)
+                                    } else {
+                                        None
+                                    }
+                                })
+                        })
+                    })
                     .map(Duration::from_secs);
 
                 Err(Error::RateLimit {

--- a/src/client.rs
+++ b/src/client.rs
@@ -131,7 +131,7 @@ impl LangfuseClient {
             .timeout(Duration::from_secs(5))
             .send()
             .await
-            .map_err(|e| Error::Network(e))?;
+            .map_err(Error::Network)?;
 
         // Check if we got a successful response
         match response.status() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -120,7 +120,7 @@ impl LangfuseClient {
     /// Validate that the client credentials are valid
     pub async fn validate(&self) -> Result<bool> {
         use crate::error::Error;
-        
+
         // Make a lightweight request to the health endpoint
         let url = format!("{}/api/public/health", self.base_url);
         let response = self

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -19,9 +19,20 @@ pub struct TraceResponse {
 impl TraceResponse {
     /// Get the Langfuse URL for this trace
     pub fn url(&self) -> String {
-        // Remove /api if present from base_url
-        let web_url = self.base_url.replace("/api", "");
-        format!("{}/trace/{}", web_url.trim_end_matches('/'), self.id)
+        // More robust URL construction that handles various base_url formats
+        let mut web_url = self.base_url.clone();
+        
+        // Remove trailing slashes
+        web_url = web_url.trim_end_matches('/').to_string();
+        
+        // Replace /api/public or /api at the end with empty string
+        if web_url.ends_with("/api/public") {
+            web_url = web_url[..web_url.len() - 11].to_string();
+        } else if web_url.ends_with("/api") {
+            web_url = web_url[..web_url.len() - 4].to_string();
+        }
+        
+        format!("{}/trace/{}", web_url, self.id)
     }
 }
 

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -21,17 +21,17 @@ impl TraceResponse {
     pub fn url(&self) -> String {
         // More robust URL construction that handles various base_url formats
         let mut web_url = self.base_url.clone();
-        
+
         // Remove trailing slashes
         web_url = web_url.trim_end_matches('/').to_string();
-        
+
         // Replace /api/public or /api at the end with empty string
         if web_url.ends_with("/api/public") {
             web_url = web_url[..web_url.len() - 11].to_string();
         } else if web_url.ends_with("/api") {
             web_url = web_url[..web_url.len() - 4].to_string();
         }
-        
+
         format!("{}/trace/{}", web_url, self.id)
     }
 }

--- a/tests/mock_tests.rs
+++ b/tests/mock_tests.rs
@@ -62,7 +62,7 @@ async fn test_validate_success() {
 
     mock.assert_async().await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), true);
+    assert!(result.unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Implement `client.validate()` method with actual API health check
- Fix Retry-After header parsing to support both integer and HTTP-date formats  
- Improve trace URL construction to handle various base_url formats correctly

## Changes
- **validate()**: Now makes actual health endpoint request instead of returning hardcoded true
- **Retry-After parsing**: Support both seconds (integer) and HTTP-date (RFC2822) formats per RFC 2616
- **URL construction**: More robust handling of various base_url formats (/api/public, /api, etc.)

## Test plan
- [x] Added tests for validate() success and auth error cases
- [x] All existing tests pass
- [x] Manual testing with mockito server

Part of addressing feedback from langfuse-client-base improvements.