### PR TITLE
fix: update branch protection check names to match CI output

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -49,13 +49,20 @@ branches:
       required_status_checks:
         strict: true  # Require branches to be up to date before merging
         contexts:
+          # From CI workflow
           - "Security Audit"
-          - "Test Suite (macos-latest, stable)"
-          - "Test Suite (macos-latest, beta)"
-          - "Test Suite (ubuntu-latest, stable)"
-          - "Test Suite (ubuntu-latest, beta)"
-          - "Test Suite (windows-latest, stable)"
-          - "Test Suite (windows-latest, beta)"
+          - "Test Suite (macos-latest / stable)"
+          - "Test Suite (macos-latest / beta)"
+          - "Test Suite (ubuntu-latest / stable)"
+          - "Test Suite (ubuntu-latest / beta)"
+          - "Test Suite (windows-latest / stable)"
+          - "Test Suite (windows-latest / beta)"
+          # Optional checks (not required but shown in PR)
+          # - "Feature Combinations"
+          # - "Code Coverage"
+          # - "Check Unused Dependencies"
+          # - "TruffleHog Secrets Scan"
+          # - "Gitleaks Secrets Scan"
       
       # Enforce for admins
       enforce_admins: false


### PR DESCRIPTION
## Critical Fix

The branch protection rules in `.github/settings.yml` were using the wrong format for CI check names, which was blocking all PR merges.

## Issue
- CI generates check names like: `Test Suite (ubuntu-latest / stable)` 
- Settings file had: `Test Suite (ubuntu-latest, stable)`
- The mismatch meant required checks never passed

## Solution
Updated all check names in `.github/settings.yml` to match the actual CI output format with spaces after the slash.

## Notes
- The GitHub Settings app (if installed) should automatically apply these changes
- Alternatively, they can be manually applied in GitHub settings
- This unblocks all pending PRs (#29, #30, #31, #32)

This is a critical fix that should be merged ASAP to unblock development.