### PR TITLE
feat: improve error handling with better status mapping

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,9 @@ use std::fmt;
 use std::time::Duration;
 use thiserror::Error;
 
+/// Result type for Langfuse operations
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("API error: {0}")]
@@ -80,8 +83,6 @@ pub enum Error {
         reason: String,
     },
 }
-
-pub type Result<T> = std::result::Result<T, Error>;
 
 /// Error details for individual events in a batch
 #[derive(Debug, Clone)]
@@ -359,5 +360,47 @@ mod tests {
         assert!(display.contains("minimal-id"));
         assert!(display.contains("Minimal error"));
         assert!(!display.contains("retryable"));
+    }
+}
+
+/// Helper to map API errors to appropriate error types based on status code
+pub fn map_api_error<E: std::fmt::Display>(err: E) -> Error {
+    let error_str = err.to_string();
+    
+    // Try to extract status code from error message
+    if error_str.contains("401") || error_str.contains("Unauthorized") {
+        Error::Auth {
+            message: error_str,
+            request_id: None,
+        }
+    } else if error_str.contains("403") || error_str.contains("Forbidden") {
+        Error::Auth {
+            message: error_str,
+            request_id: None,
+        }
+    } else if error_str.contains("429") || error_str.contains("Too Many Requests") {
+        Error::RateLimit {
+            retry_after: None,
+            request_id: None,
+        }
+    } else if error_str.contains("500") || error_str.contains("Internal Server Error") 
+            || error_str.contains("502") || error_str.contains("Bad Gateway")
+            || error_str.contains("503") || error_str.contains("Service Unavailable")
+            || error_str.contains("504") || error_str.contains("Gateway Timeout") {
+        Error::Server {
+            status: 500,
+            message: error_str,
+            request_id: None,
+        }
+    } else if error_str.contains("400") || error_str.contains("Bad Request")
+            || error_str.contains("404") || error_str.contains("Not Found")
+            || error_str.contains("422") || error_str.contains("Unprocessable Entity") {
+        Error::Client {
+            status: 400,
+            message: error_str,
+            request_id: None,
+        }
+    } else {
+        Error::Api(error_str)
     }
 }

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -175,7 +175,7 @@ impl LangfuseClient {
                 id: trace_id,
                 base_url: self.configuration().base_path.clone(),
             })
-            .map_err(|e| crate::error::map_api_error(e))
+            .map_err(crate::error::map_api_error)
     }
 
     /// Get a trace by ID
@@ -186,7 +186,7 @@ impl LangfuseClient {
 
         let trace = trace_api::trace_get(self.configuration(), &trace_id)
             .await
-            .map_err(|e| crate::error::map_api_error(e))?;
+            .map_err(crate::error::map_api_error)?;
 
         serde_json::to_value(trace)
             .map_err(|e| crate::error::Error::Api(format!("Failed to serialize trace: {}", e)))

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -175,7 +175,7 @@ impl LangfuseClient {
                 id: trace_id,
                 base_url: self.configuration().base_path.clone(),
             })
-            .map_err(|e| crate::error::Error::Api(format!("Failed to create trace: {}", e)))
+            .map_err(|e| crate::error::map_api_error(e))
     }
 
     /// Get a trace by ID
@@ -186,7 +186,7 @@ impl LangfuseClient {
 
         let trace = trace_api::trace_get(self.configuration(), &trace_id)
             .await
-            .map_err(|e| crate::error::Error::Api(format!("Failed to get trace: {}", e)))?;
+            .map_err(|e| crate::error::map_api_error(e))?;
 
         serde_json::to_value(trace)
             .map_err(|e| crate::error::Error::Api(format!("Failed to serialize trace: {}", e)))

--- a/tests/mock_tests.rs
+++ b/tests/mock_tests.rs
@@ -143,10 +143,16 @@ async fn test_rate_limiting_handling() {
 
     if let Err(error) = result {
         // Check that it's a rate limit error
-        assert!(error.is_retryable(), "Rate limit errors should be retryable");
+        assert!(
+            error.is_retryable(),
+            "Rate limit errors should be retryable"
+        );
         let error_str = error.to_string();
-        assert!(error_str.contains("Rate limit"), 
-                "Expected rate limit error, got: {}", error_str);
+        assert!(
+            error_str.contains("Rate limit"),
+            "Expected rate limit error, got: {}",
+            error_str
+        );
     }
 }
 

--- a/tests/mock_tests.rs
+++ b/tests/mock_tests.rs
@@ -142,7 +142,11 @@ async fn test_rate_limiting_handling() {
     assert!(result.is_err(), "Should fail with rate limit error");
 
     if let Err(error) = result {
-        assert!(error.to_string().contains("429") || error.to_string().contains("rate"));
+        // Check that it's a rate limit error
+        assert!(error.is_retryable(), "Rate limit errors should be retryable");
+        let error_str = error.to_string();
+        assert!(error_str.contains("Rate limit"), 
+                "Expected rate limit error, got: {}", error_str);
     }
 }
 


### PR DESCRIPTION
## Summary
Implements error handling improvements from feedback for better error categorization.

## Changes

### Error Mapping
- Added `map_api_error()` helper function to map errors based on status codes
- Automatically categorizes errors:
  - 401/403 → `Error::Auth`
  - 429 → `Error::RateLimit`
  - 5xx → `Error::Server`
  - 4xx → `Error::Client`
  - Others → `Error::Api`

### API Error Handling
- Updated trace API calls to use `map_api_error` instead of generic `Error::Api`
- Provides better error context for callers
- Request IDs can be added in future improvements

### Code Cleanup
- Removed duplicate `Result` type definition
- Consolidated error handling logic

## Test plan
- [x] All existing tests pass
- [x] Compilation successful
- [ ] Add tests for map_api_error function

Part of addressing feedback from langfuse-client-base improvements.