### PR TITLE
fix: documentation inconsistencies and code cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,14 +104,23 @@ cargo run --example multiple_traces
 - Environment-based configuration
 - Trace metadata, tags, input/output
 - Session and user tracking
-
-### Not Yet Implemented ❌
 - Observations (spans, generations, events)
 - Scoring system (numeric, binary, categorical)
 - Fetching existing traces
-- Batch operations
+- Batch operations with advanced features:
+  - Automatic retries with exponential backoff
+  - 207 Multi-Status response handling
+  - 413 Payload Too Large handling with automatic chunking
+  - Backpressure policies (Block, DropNew, DropOldest)
+  - Metrics tracking
+  - Graceful shutdown
 - Dataset management
-- Prompt management
+- Prompt management (basic - get/create)
+
+### Not Yet Implemented ❌
+- Advanced prompt versioning and caching
+- Full dataset item operations
+- Observation updates/deletions
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .output(json!({"response": "Hi there!"}))
         .user_id("user-123")
         .tags(["production", "chat"])
-        .send()
+        .call()
         .await?;
     
     println!("Created trace: {}", trace.id);

--- a/examples/comprehensive_batch_test.rs
+++ b/examples/comprehensive_batch_test.rs
@@ -282,11 +282,11 @@ async fn main() -> anyhow::Result<()> {
     );
     if !trace_ids.is_empty() {
         println!(
-            "   First trace: https://cloud.langfuse.com/traces/{}",
+            "   First trace: https://cloud.langfuse.com/trace/{}",
             trace_ids[0]
         );
         println!(
-            "   Last trace: https://cloud.langfuse.com/traces/{}",
+            "   Last trace: https://cloud.langfuse.com/trace/{}",
             trace_ids[trace_ids.len() - 1]
         );
     }

--- a/examples/trace_with_metadata.rs
+++ b/examples/trace_with_metadata.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("✅ Created trace with full metadata");
     println!("   Trace ID: {}", trace.id);
-    println!("   View at: https://cloud.langfuse.com/traces/{}", trace.id);
+    println!("   View at: https://cloud.langfuse.com/trace/{}", trace.id);
 
     Ok(())
 }

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -281,7 +281,6 @@ impl LangfuseClient {
         use langfuse_client_base::apis::ingestion_api;
         use langfuse_client_base::models::{
             CreateSpanBody, IngestionBatchRequest, IngestionEvent, IngestionEventOneOf2,
-            ObservationLevel,
         };
 
         let observation_id = id.unwrap_or_else(|| Uuid::new_v4().to_string());
@@ -298,13 +297,7 @@ impl LangfuseClient {
                 .map(|t| Some(t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))),
             input: input.map(Some),
             output: output.map(Some),
-            level: level.map(|l| match l.as_str() {
-                "DEBUG" => ObservationLevel::Debug,
-                "DEFAULT" => ObservationLevel::Default,
-                "WARNING" => ObservationLevel::Warning,
-                "ERROR" => ObservationLevel::Error,
-                _ => ObservationLevel::Default,
-            }),
+            level: level.map(|l| parse_observation_level(&l)),
             status_message: status_message.map(Some),
             parent_observation_id: parent_observation_id.map(Some),
             version: None,
@@ -355,7 +348,6 @@ impl LangfuseClient {
         use langfuse_client_base::apis::ingestion_api;
         use langfuse_client_base::models::{
             CreateGenerationBody, IngestionBatchRequest, IngestionEvent, IngestionEventOneOf4,
-            ObservationLevel,
         };
 
         let observation_id = id.unwrap_or_else(|| Uuid::new_v4().to_string());
@@ -379,13 +371,7 @@ impl LangfuseClient {
             usage_details: None,
             cost_details: None,
             metadata: metadata.map(Some),
-            level: level.map(|l| match l.as_str() {
-                "DEBUG" => ObservationLevel::Debug,
-                "DEFAULT" => ObservationLevel::Default,
-                "WARNING" => ObservationLevel::Warning,
-                "ERROR" => ObservationLevel::Error,
-                _ => ObservationLevel::Default,
-            }),
+            level: level.map(|l| parse_observation_level(&l)),
             status_message: status_message.map(Some),
             parent_observation_id: parent_observation_id.map(Some),
             version: None,
@@ -431,7 +417,6 @@ impl LangfuseClient {
         use langfuse_client_base::apis::ingestion_api;
         use langfuse_client_base::models::{
             CreateEventBody, IngestionBatchRequest, IngestionEvent, IngestionEventOneOf6,
-            ObservationLevel,
         };
 
         let observation_id = id.unwrap_or_else(|| Uuid::new_v4().to_string());
@@ -446,13 +431,7 @@ impl LangfuseClient {
             start_time: Some(Some(timestamp.clone())),
             input: input.map(Some),
             output: output.map(Some),
-            level: level.map(|l| match l.as_str() {
-                "DEBUG" => ObservationLevel::Debug,
-                "DEFAULT" => ObservationLevel::Default,
-                "WARNING" => ObservationLevel::Warning,
-                "ERROR" => ObservationLevel::Error,
-                _ => ObservationLevel::Default,
-            }),
+            level: level.map(|l| parse_observation_level(&l)),
             status_message: status_message.map(Some),
             parent_observation_id: parent_observation_id.map(Some),
             version: None,


### PR DESCRIPTION
## Summary
- Fix README method name: `.send()` → `.call()` to match actual API
- Fix example URLs: `/traces/{id}` → `/trace/{id}` to match TraceResponse::url()
- Update CLAUDE.md to reflect current implementation status
- Use `parse_observation_level()` helper consistently instead of duplicated matches
- Remove unused ObservationLevel imports

## Context
Based on review feedback about consistency and maintainability. These are quick wins that improve documentation accuracy and reduce code duplication.

## Test Plan
- [x] All tests pass
- [x] cargo fmt passes
- [x] cargo clippy passes