### PR TITLE
fix: improve error messages with context

### DIFF
--- a/src/traces.rs
+++ b/src/traces.rs
@@ -250,6 +250,7 @@ impl LangfuseClient {
         use langfuse_client_base::apis::trace_api;
         use langfuse_client_base::models::TraceDeleteMultipleRequest;
 
+        let trace_count = trace_ids.len();
         let request = TraceDeleteMultipleRequest {
             trace_ids, // Remove the Some() wrapper
         };
@@ -257,7 +258,7 @@ impl LangfuseClient {
         trace_api::trace_delete_multiple(self.configuration(), request)
             .await
             .map(|_| ()) // Ignore the response body, just return success
-            .map_err(|e| crate::error::Error::Api(format!("Failed to delete {} traces: {}", trace_ids.len(), e)))
+            .map_err(|e| crate::error::Error::Api(format!("Failed to delete {} traces: {}", trace_count, e)))
     }
 
     // ===== OBSERVATIONS (SPANS, GENERATIONS, EVENTS) =====

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -242,7 +242,7 @@ impl LangfuseClient {
         trace_api::trace_delete(self.configuration(), &trace_id)
             .await
             .map(|_| ()) // Ignore the response body, just return success
-            .map_err(|e| crate::error::Error::Api(format!("Failed to delete trace: {}", e)))
+            .map_err(|e| crate::error::Error::Api(format!("Failed to delete trace '{}': {}", trace_id, e)))
     }
 
     /// Delete multiple traces
@@ -257,7 +257,7 @@ impl LangfuseClient {
         trace_api::trace_delete_multiple(self.configuration(), request)
             .await
             .map(|_| ()) // Ignore the response body, just return success
-            .map_err(|e| crate::error::Error::Api(format!("Failed to delete traces: {}", e)))
+            .map_err(|e| crate::error::Error::Api(format!("Failed to delete {} traces: {}", trace_ids.len(), e)))
     }
 
     // ===== OBSERVATIONS (SPANS, GENERATIONS, EVENTS) =====


### PR DESCRIPTION
## Summary
Small improvement to error messages to include more context for debugging.

## Changes
- Add trace ID to delete error messages
- Include count of traces being deleted in batch delete operations

## Context
Based on review feedback about improving error handling. While we can't easily extract HTTP status codes from the OpenAPI-generated client errors, we can at least make the error messages more informative.

## Test Plan
- [x] Code compiles
- [x] Tests pass