### PR TITLE
fix: suppress false positive security alerts for session_id/user_id

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,15 @@
+# CodeQL configuration for langfuse-ergonomic
+# This file configures CodeQL code scanning to reduce false positives
+
+name: "CodeQL config for langfuse-ergonomic"
+
+# Query filters to suppress false positives
+query-filters:
+  - exclude:
+      id: js/clear-text-logging
+      # session_id and user_id in Langfuse are NOT secrets
+      # They are identifiers for organizing/filtering traces, not authentication credentials
+      # Suppressing false positives for these specific identifiers in examples
+      paths:
+        - examples/comprehensive_batch_test.rs
+        - examples/multiple_traces.rs

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,6 +56,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: 'rust'
+          config-file: ./.github/codeql/codeql-config.yml
           
       - name: Build
         run: cargo build --verbose

--- a/examples/comprehensive_batch_test.rs
+++ b/examples/comprehensive_batch_test.rs
@@ -51,10 +51,15 @@ async fn main() -> anyhow::Result<()> {
     println!("\n{}", "=".repeat(50));
     println!("Creating test events...\n");
 
+    // Note: session_id and user_id are NOT secrets in Langfuse context
+    // They are identifiers for organizing/filtering traces, not authentication credentials
     let session_id = format!("batch-test-session-{}", Uuid::new_v4());
     let user_id = "test-user-batch";
 
+    // Safe to log: these are trace organization identifiers, not secrets
+    // codeql[rust/cleartext-logging] - False positive: session_id is not a secret
     println!("📁 Session ID: {}", session_id);
+    // codeql[rust/cleartext-logging] - False positive: user_id is not a secret
     println!("👤 User ID: {}\n", user_id);
 
     // Create multiple traces to test batching

--- a/examples/multiple_traces.rs
+++ b/examples/multiple_traces.rs
@@ -12,9 +12,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Connected to Langfuse");
 
     // Create a session ID to link multiple traces
+    // Note: session_id and user_id are NOT secrets - they're identifiers for organizing traces
     let session_id = format!("session-{}", Uuid::new_v4());
     let user_id = "user-123";
 
+    // Safe to log: session_id is a trace organization identifier, not an authentication secret
+    // codeql[rust/cleartext-logging] - False positive: session_id is not a secret
     println!("📝 Creating conversation session: {}", session_id);
 
     // First trace: User asks a question


### PR DESCRIPTION
## Summary

Addresses false positive security alerts from CodeQL scanning that incorrectly flag `session_id` and `user_id` as sensitive information being logged in cleartext.

## Context

In Langfuse, `session_id` and `user_id` are **NOT secrets or sensitive information**. They are:
- Public identifiers used for organizing and filtering traces
- Meant to be user-provided values for tracking purposes  
- Similar to usernames or session identifiers in analytics
- NOT authentication credentials that need to be kept secret

## Changes

1. **Added clarifying comments** in the code explaining these are not secrets
2. **Added CodeQL suppression comments** to mark these as false positives
3. **Created CodeQL configuration file** to suppress these specific alerts
4. **Updated security workflow** to use the CodeQL configuration

## Testing

The changes only add comments and configuration - no functional code changes.

## References

- [GitHub Security Scanning Alerts](https://github.com/genai-rs/langfuse-ergonomic/security/code-scanning)
- Alert #1: examples/multiple_traces.rs line 7
- Alert #2: examples/comprehensive_batch_test.rs line 9

These suppressions are appropriate because session_id and user_id in the Langfuse context are organizational identifiers, not authentication secrets.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>