### PR TITLE
fix: restore changelog in GitHub releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,9 +11,15 @@ git_tag_enable = true
 
 # Git release body template - ensures GitHub releases have proper content
 git_release_body = """
-{{ changelog }}
+## What's Changed
 
-**Full Changelog**: {{ remote.compare_url }}
+{%- if changelog %}
+{{ changelog }}
+{%- else %}
+_No changelog available_
+{%- endif %}
+
+**Full Changelog**: https://github.com/genai-rs/langfuse-ergonomic/compare/{{ previous_version }}...{{ version }}
 """
 
 # PR settings


### PR DESCRIPTION
## Problem

The last two releases (v0.2.1 and v0.3.0) have empty descriptions on GitHub, missing the changelog content that was present in earlier releases like v0.1.1.

## Root Cause

The `git_release_body` template in `release-plz.toml` was changed to use `{{ changelog }}` directly without checking if it exists. When the variable is empty/undefined, the entire release body becomes empty.

## Solution

Updated the release body template to:
1. Add conditional check `{%- if changelog %}` to handle empty changelog
2. Provide fallback message when changelog is not available
3. Restore the working compare URL format using `{{ previous_version }}...{{ version }}`
4. Match the configuration that works in `langfuse-client-base`

## Testing

After this is merged, the next release should properly display the changelog in the GitHub release description.

## Before
```
(empty release description)
```

## After
```
## What's Changed

### Added
- feature descriptions...

### Fixed
- bug fixes...

**Full Changelog**: https://github.com/genai-rs/langfuse-ergonomic/compare/v0.3.0...v0.4.0
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>