### PR TITLE
chore: upgrade langfuse-client-base to v0.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This is the **langfuse-ergonomic** repository - an ergonomic wrapper for the Lan
 This repository was migrated from the monorepo at timvw/langfuse-rs to a standalone repository in the genai-rs organization. Key changes:
 
 1. **Standalone Repository**: Converted from workspace member to standalone package
-2. **Dependencies**: Now depends on published langfuse-client-base crate from crates.io (v0.1)
+2. **Dependencies**: Now depends on published langfuse-client-base crate from crates.io (v0.3)
 3. **Simplified Configuration**: Removed workspace configuration from release-plz.toml
 4. **Structure**: All code moved from subdirectory to repository root
 5. **CI/CD**: Retained full test matrix as this contains manually written code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ unescaped_backticks = "warn"
 
 
 [dependencies]
-langfuse-client-base = "0.2"
+langfuse-client-base = "0.3"
 bon = "3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- Upgraded langfuse-client-base dependency from v0.2 to v0.3
- Updated documentation to reflect new version

## Changes
- Updated Cargo.toml dependency version
- Updated CLAUDE.md documentation

## Test Plan
- [x] All existing tests pass
- [x] All examples compile successfully  
- [x] Pre-commit checks (fmt, clippy, test) pass

No breaking changes were introduced by this upgrade.

🤖 Generated with [Claude Code](https://claude.ai/code)