### PR TITLE
chore: align renovate config with library defaults

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -128,8 +128,7 @@
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
-    "assignees": ["@timvw"],
-    "prPriority": 100  // Highest priority
+    "assignees": ["timvw"]
   },
   
   // ========================================
@@ -137,6 +136,6 @@
   // ========================================
   "rust": {
     "enabled": true,
-    "rangeStrategy": "bump"  // Use exact versions in Cargo.toml
+    "rangeStrategy": "update-lockfile"  // Update Cargo.lock while keeping flexible Cargo.toml ranges
   }
 }


### PR DESCRIPTION
## Summary
- align Renovate rust range strategy with opentelemetry-langfuse
- keep vulnerability alert handling consistent

## Testing
- npx -y --package renovate renovate-config-validator renovate.json5